### PR TITLE
jx-scala-akka-http-demo-app to 0.0.1

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -7,6 +7,9 @@ dependencies:
   name: exposecontroller
   repository: http://chartmuseum.jenkins-x.io
   version: 2.3.82
+- name: jx-scala-akka-http-demo-app
+  repository: http://jenkins-x-chartmuseum:8080
+  version: 0.0.1
 - name: jx-spring-demo-app
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.2


### PR DESCRIPTION
Promote jx-scala-akka-http-demo-app to version 0.0.1