### PR TITLE
jx-scala-akka-http-demo-app to 0.0.2

### DIFF
--- a/env/requirements.yaml
+++ b/env/requirements.yaml
@@ -12,7 +12,7 @@ dependencies:
   version: 0.0.2
 - name: jx-scala-akka-http-demo-app
   repository: http://jenkins-x-chartmuseum:8080
-  version: 0.0.1
+  version: 0.0.2
 - name: jx-spring-demo-app
   repository: http://jenkins-x-chartmuseum:8080
   version: 0.0.2


### PR DESCRIPTION
Promote jx-scala-akka-http-demo-app to version 0.0.2